### PR TITLE
chore(package): update nock to version 9.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-standard": "^3.0.1",
     "jest": "^22.0.0",
-    "nock": "^9.0.22",
+    "nock": "^9.3.1",
     "nodemon": "^1.14.11",
     "nyc": "^12.0.1",
     "should": "^13.2.0",


### PR DESCRIPTION
closes #82 