### PR TITLE
chore(package): update sequelize to version 4.38.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "mysql": "^2.15.0",
     "mysql2": "^1.4.2",
     "raven": "^2.2.1",
-    "sequelize": "^4.32.1",
+    "sequelize": "^4.38.0",
     "sqlite3": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
closes #86 